### PR TITLE
feat: improve federation discovery, FlexBool parsing, SSE auto-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A fast, modern web map for [Freifunk](https://freifunk.net/) mesh networks. Buil
 - **Search** by hostname, node ID, or model
 - **Device deprecation warnings** for end-of-life hardware
 - **No external CDN** — all vendor assets (Leaflet, uPlot) are bundled
+- **Privacy-friendly** — the only external request is to OpenStreetMap tile servers for the map background
 
 ## Quick Start
 

--- a/internal/federation/discover.go
+++ b/internal/federation/discover.go
@@ -371,7 +371,7 @@ func ParseNodelistToMeshviewer(data []byte) (*store.MeshviewerData, error) {
 		rn := store.RawNode{
 			NodeID:   nodeID,
 			Hostname: n.Name,
-			IsOnline: ifaceToBool(n.Status.Online),
+			IsOnline: store.FlexBool(ifaceToBool(n.Status.Online)),
 			Clients:  ifaceToInt(n.Status.Clients),
 			Lastseen: ifaceToString(n.Status.Lastcontact),
 			MAC:      nodeID,


### PR DESCRIPTION
## Summary

Improve federation discovery to handle more community data formats and fix several issues with node discovery.

## Changes

### FlexBool parsing
- Add `FlexBool` custom JSON type that handles booleans encoded as strings (`"1"`/`"0"`/`""`) in meshviewer.json — fixes communities like Rhein-Sieg whose yanic output uses string-encoded booleans

### dataPath discovery
- Resolve relative `dataPath` URLs from inline meshviewer HTML config to absolute HTTP URLs — fixes communities that embed config inline instead of serving `config.json`
- Fetch **all** dataPath sources instead of only the first, so multi-domain communities (e.g. Rhein-Sieg with 16 domains) get all their nodes discovered
- Re-probe stale grafana cache entries that only contain relative DataPaths
- Skip relative DataPaths when adding sources as a safety net

### SSE auto-refresh
- Broadcast SSE update after background federation refresh completes, so the browser automatically refreshes when new data arrives after startup from cache

### Stats deduplication
- Deduplicate communities in stats tab by metacommunity name (e.g. "Freifunk Franken" instead of 14 separate entries)
- Detect shared-source communities by matching node counts and keep the one with the highest API-reported count (fixes Muenchen/Ulm duplication)

### Config
- Add `eolInfoURL` config field — removes hardcoded FFMUC EOL device link
- Add privacy note to README about OpenStreetMap being the only external request

## Testing
- Verified Zeughausstrasse-01/02/03 nodes from Rhein-Sieg now appear (were completely missing before)
- Total node count increased from ~33.8k to ~34.9k with the new sources
- `go build ./...` passes cleanly
