### PR TITLE
fix: trigger full data reload via SSE when new/removed nodes detected

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1102,6 +1102,13 @@
     }
     if (update.type === 'full') { loadData(); return; }
 
+    // If there are new or removed nodes, do a full reload since we don't
+    // have the full node data in the diff — only IDs
+    if ((update.new && update.new.length) || (update.gone && update.gone.length)) {
+      loadData();
+      return;
+    }
+
     let needsMarkerUpdate = false;
     if (update.changed) {
       update.changed.forEach(diff => {
@@ -1119,7 +1126,6 @@
         }
       });
     }
-    if ((update.new && update.new.length) || (update.gone && update.gone.length)) needsMarkerUpdate = true;
     if (needsMarkerUpdate) renderMarkers();
   }
 


### PR DESCRIPTION
SSE diff updates only contained node IDs for new/removed nodes, not full node data. The frontend tried to re-render markers from the stale nodes array, so new nodes never appeared until manual reload.

Now when the SSE diff contains new or removed nodes, the frontend does a full `loadData()` to re-fetch all nodes. For regular diffs (online/offline, client count changes) it still does the efficient in-place update.