### PR TITLE
security: fix critical and high severity findings

### DIFF
--- a/internal/federation/grafana.go
+++ b/internal/federation/grafana.go
@@ -64,7 +64,8 @@ func SaveGrafanaCache(cache GrafanaCache) {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(grafanaCacheFile, data, 0644)
+	_ = os.WriteFile(grafanaCacheFile+".tmp", data, 0644)
+	_ = os.Rename(grafanaCacheFile+".tmp", grafanaCacheFile)
 	log.Printf("Grafana cache: saved %d entries to %s", len(cache), grafanaCacheFile)
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -241,7 +241,8 @@ func (s *Store) Refresh() error {
 		return fmt.Errorf("unexpected status %d from data source", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	const maxBodySize = 20 * 1024 * 1024 // 20 MB
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodySize))
 	if err != nil {
 		return fmt.Errorf("reading body: %w", err)
 	}

--- a/internal/urlcheck/urlcheck.go
+++ b/internal/urlcheck/urlcheck.go
@@ -1,0 +1,51 @@
+package urlcheck
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// IsSafeURL checks that a URL is safe to fetch (blocks private IPs, metadata endpoints).
+func IsSafeURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	blocked := []string{"169.254.169.254", "metadata.google.internal", "100.100.100.200"}
+	for _, b := range blocked {
+		if host == b {
+			return false
+		}
+	}
+	ip := net.ParseIP(host)
+	if ip != nil {
+		return !isPrivateIP(ip)
+	}
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return true
+	}
+	for _, addr := range addrs {
+		if pip := net.ParseIP(addr); pip != nil && isPrivateIP(pip) {
+			return false
+		}
+	}
+	return true
+}
+
+func isPrivateIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
+}
+
+// IsHTTPS returns true if the URL uses HTTPS.
+func IsHTTPS(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "https://")
+}

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 		Addr:         cfg.Listen,
 		Handler:      api.GzipHandler(mux),
 		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 0,
+		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
 

--- a/web/app.js
+++ b/web/app.js
@@ -325,7 +325,7 @@
       const hasPos = n.lat != null && n.lng != null;
       const age = Math.floor((now - new Date(n.firstseen).getTime()) / 86400000);
       const ageStr = age === 0 ? 'today' : age + 'd ago';
-      html += `<div class="node-list-item" onclick="window.FFMap.selectNode('${n.node_id}')" style="font-size:12px">
+      html += `<div class="node-list-item" onclick="window.FFMap.selectNode('${escAttr(n.node_id)}')" style="font-size:12px">
         <span class="node-status online" style="width:8px;height:8px;flex-shrink:0"></span>
         ${hasPos ? '<span style="font-size:10px;flex-shrink:0">🌍</span>' : '<span style="width:14px;flex-shrink:0"></span>'}
         <span class="hostname">${esc(n.hostname)}</span>
@@ -504,7 +504,7 @@
     if (node.nproc) html += detailRow('CPUs', node.nproc);
     html += detailRow('Autoupdater', node.autoupdater ? `✓ ${node.branch}` : '✗ off');
     if (node.addresses && node.addresses.length > 0) {
-      html += detailRow('Addresses', `<span style="font-size:11px;word-break:break-all">${node.addresses.join('<br>')}</span>`);
+      html += detailRowHTML('Addresses', `<span style="font-size:11px;word-break:break-all">${node.addresses.map(a => esc(a)).join('<br>')}</span>`);
     }
     html += `</dl>`;
 
@@ -535,7 +535,7 @@
       node.neighbour_details.forEach(nb => {
         const dist = nb.distance > 0 ? ` · ${formatDistance(nb.distance)}` : '';
         const tq = nb.tq > 0 ? ` · TQ ${(nb.tq * 100).toFixed(0)}%` : '';
-        html += `<li class="neighbour-item" onclick="window.FFMap.selectNode('${nb.node_id}')">
+        html += `<li class="neighbour-item" onclick="window.FFMap.selectNode('${escAttr(nb.node_id)}')">
           <span class="node-status ${nb.is_online ? 'online' : 'offline'}" style="width:8px;height:8px"></span>
           <span>${esc(nb.hostname || nb.node_id)}</span>
           <span style="color:var(--fg-muted);font-size:12px;margin-left:auto">${nb.link_type || ''}${tq}${dist}</span>
@@ -1282,7 +1282,7 @@
       const linkCount = n.neighbours?.length || 0;
       const uptimeStr = (n.is_online && n.uptime && n.uptime !== '0001-01-01T00:00:00+0000') ? formatUptime(n.uptime) : '';
       const hasPos = (n.lat != null && n.lng != null);
-      html += `<div class="node-list-item" onclick="window.FFMap.selectNode('${n.node_id}')">
+      html += `<div class="node-list-item" onclick="window.FFMap.selectNode('${escAttr(n.node_id)}')">
         <span class="node-status ${n.is_online ? 'online' : 'offline'}" style="width:8px;height:8px;flex-shrink:0"></span>
         ${hasPos ? '<span title="Has location" style="font-size:10px;flex-shrink:0">🌍</span>' : '<span style="width:14px;flex-shrink:0"></span>'}
         <span class="hostname">${esc(n.hostname)}</span>
@@ -1304,7 +1304,7 @@
       ).slice(0, 10);
       if (!matches.length) { results.classList.add('hidden'); return; }
       results.innerHTML = matches.map(n =>
-        `<div class="search-item" onclick="window.FFMap.selectNode('${n.node_id}');document.getElementById('search-results').classList.add('hidden')">
+        `<div class="search-item" onclick="window.FFMap.selectNode('${escAttr(n.node_id)}');document.getElementById('search-results').classList.add('hidden')">
           <span class="node-status ${n.is_online ? 'online' : 'offline'}" style="width:8px;height:8px"></span>
           ${esc(n.hostname)}
         </div>`
@@ -1385,7 +1385,9 @@
   // ────────────────────── Helpers ──────────────────────
   async function fetchJSON(url) { const r = await fetch(url); if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); }
   function esc(s) { if (!s) return ''; const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
-  function detailRow(l, v) { return `<dt>${l}</dt><dd>${v || '-'}</dd>`; }
+  function escAttr(s) { return esc(s).replace(/'/g, '&#39;').replace(/"/g, '&quot;'); }
+  function detailRow(l, v) { return `<dt>${esc(l)}</dt><dd>${v != null && v !== '' ? esc(String(v)) : '-'}</dd>`; }
+  function detailRowHTML(l, v) { return `<dt>${esc(l)}</dt><dd>${v || '-'}</dd>`; }
   function progressBar(v) {
     const p = Math.min(Math.max(v * 100, 0), 100);
     return `<div class="progress-bar"><div class="progress-fill ${p < 60 ? 'bar-green' : p < 85 ? 'bar-yellow' : 'bar-red'}" style="width:${p}%"></div></div>`;


### PR DESCRIPTION
## Security Fixes

Addresses findings #1–6 from the security audit.

### #1 SSRF Protection (Critical)
New `internal/urlcheck` package validates all outbound URLs before fetching — blocks private IPs, loopback, link-local, cloud metadata endpoints (169.254.169.254, metadata.google.internal). Applied to `fetchSource`, `ProbeURL`, and the Grafana metrics proxy.

### #2 Unbounded Response Reads (High)
All `io.ReadAll(resp.Body)` calls now use `io.LimitReader`:
- Federation source fetches: 20 MB
- Single-community refresh: 20 MB  
- API directory fetch: 10 MB
- Grafana metrics proxy: 5 MB

### #3 Cross-Site Scripting (High)
- New `escAttr()` helper escapes for JavaScript string context
- All `node_id` values in `onclick` handlers are escaped (4 locations)
- `detailRow()` now auto-escapes values
- New `detailRowHTML()` for pre-escaped content
- Individual addresses escaped in address list

### #4 SSE Client Limit (Medium)
Max 1000 concurrent SSE clients. Returns HTTP 503 when exceeded.

### #5 WriteTimeout (Medium)
Set `WriteTimeout: 60s` on the HTTP server. SSE handler disables the write deadline per-connection using `http.ResponseController`.

### #6 Atomic File Writes (Medium)
Both `federation_state.json` and `grafana_cache.json` now write to `.tmp` then `os.Rename` — prevents corruption on crash.
