### PR TITLE
feat: community clients/node ratio + fix link colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ freifunk-map-*-*
 config.json
 grafana_cache.json
 federation_state.json
+.github/copilot-instructions.md

--- a/web/app.css
+++ b/web/app.css
@@ -29,6 +29,9 @@ body {
   height: 100vh;
 }
 
+a { color: var(--accent-light); }
+a:visited { color: var(--accent-light); }
+
 #app {
   display: grid;
   grid-template-columns: var(--sidebar-width) 1fr;


### PR DESCRIPTION
- Stats tab now shows per-community breakdown: online/total nodes, clients, and clients/node ratio
- Overview card shows global clients/node ratio
- All links now use `--accent-light` color for readability on dark background
- `.github/copilot-instructions.md` added to gitignore (local deploy config)