### PR TITLE
feat: FlexInt/FlexFloat64 for resilient meshviewer parsing

### DIFF
--- a/internal/federation/discover.go
+++ b/internal/federation/discover.go
@@ -385,7 +385,7 @@ func ParseNodelistToMeshviewer(data []byte) (*store.MeshviewerData, error) {
 			NodeID:   nodeID,
 			Hostname: n.Name,
 			IsOnline: store.FlexBool(ifaceToBool(n.Status.Online)),
-			Clients:  ifaceToInt(n.Status.Clients),
+			Clients:  store.FlexInt(ifaceToInt(n.Status.Clients)),
 			Lastseen: ifaceToString(n.Status.Lastcontact),
 			MAC:      nodeID,
 		}

--- a/internal/federation/store.go
+++ b/internal/federation/store.go
@@ -145,21 +145,21 @@ func (fs *Store) SaveState() {
 			Hostname:    n.Hostname,
 			IsOnline:    store.FlexBool(n.IsOnline),
 			IsGateway:   store.FlexBool(n.IsGateway),
-			Clients:     n.Clients,
-			ClientsW24:  n.ClientsW24,
-			ClientsW5:   n.ClientsW5,
-			ClientsOth:  n.ClientsOth,
+			Clients:     store.FlexInt(n.Clients),
+			ClientsW24:  store.FlexInt(n.ClientsW24),
+			ClientsW5:   store.FlexInt(n.ClientsW5),
+			ClientsOth:  store.FlexInt(n.ClientsOth),
 			Domain:      n.Domain,
 			MAC:         n.MAC,
 			Owner:       n.Owner,
 			Uptime:      n.Uptime,
-			LoadAvg:     n.LoadAvg,
-			MemoryUsage: n.MemUsage,
-			RootfsUsage: n.RootfsUsage,
+			LoadAvg:     store.FlexFloat64(n.LoadAvg),
+			MemoryUsage: store.FlexFloat64(n.MemUsage),
+			RootfsUsage: store.FlexFloat64(n.RootfsUsage),
 			Gateway:     n.Gateway,
 			Lastseen:    n.Lastseen,
 			Firstseen:   n.Firstseen,
-			Nproc:       n.Nproc,
+			Nproc:       store.FlexInt(n.Nproc),
 			Addresses:   n.Addresses,
 			Model:       n.Model,
 			Firmware: store.RawFirmware{
@@ -519,12 +519,12 @@ func (fs *Store) fetchSource(src CommunitySource) (*store.MeshviewerData, error)
 	}
 	resp, err := fs.client.Get(src.DataURL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GET %s: %w", src.DataURL, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
+		return nil, fmt.Errorf("GET %s: status %d", src.DataURL, resp.StatusCode)
 	}
 
 	const maxBodySize = 20 * 1024 * 1024 // 20 MB


### PR DESCRIPTION
Some communities encode numeric fields (`loadavg`, `clients`, `rootfs_usage`, etc.) as strings in their meshviewer.json. This caused `json.Unmarshal` to fail, silently dropping entire communities.

### Changes
- **`FlexInt`** type: handles JSON values as `int`, `float64`, or `string` (e.g. `"3"`)
- **`FlexFloat64`** type: handles JSON values as `float64`, `string` (e.g. `"0.05"`), or `bool`
- Applied to all numeric fields in `RawNode`: `clients`, `clients_wifi*`, `loadavg`, `memory_usage`, `rootfs_usage`, `nproc`
- Updated all code that reads these fields to cast via `int()` / `float64()`
- Improved `fetchSource` error messages to include the failing URL

### Result
- Weimarnetz (109 nodes) now appears — was previously failing with `cannot unmarshal string into float64`
- Any other community with string-encoded numerics will now parse correctly
- Total nodes: ~35,849 (up from ~35,750)
